### PR TITLE
Specify TLS version to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ clients.
 
 You are now ready to send a message to a user.
 
-1. Establish a TLS connection to the desired user's IP address and port.
+1. Establish a TLS 1.2 connection to the desired user's IP address and port.
 
 2. Send a string of at most 533 characters.
 


### PR DESCRIPTION
Since all clients in a given network can reasonably be expected to be very modern software, there should be no reason to support fallback to older versions of TLS or SSL. A request for fallback is probably at best a purposeless loss of security, and at worst a sign of an active attack.
In theory, it should be no more difficult to specify the desired protocol version than it would be to support version negotiation with fallback.
